### PR TITLE
Added new latency defs to Fping module, including return values

### DIFF
--- a/lib/net/fping.rb
+++ b/lib/net/fping.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Net
   module Fping
     class << self
@@ -18,6 +20,24 @@ module Net
 
       def alive_in_range(from, to)
         %x[fping -ag #{from} #{to} 2>/dev/null].split("\n")
+      end
+      
+      # Added defs for latency based metrics
+      def latency_simple(host)
+        bytes = 68
+        count = 6
+        interval = 1000
+        %x[fping -b #{bytes} -c #{count} -q -p #{interval} #{host}]
+      end
+
+      def latency(host, bytes, count, interval)
+        cmd = "fping -b #{bytes} -c #{count} -q -p #{interval} #{host}"
+        Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+          # output is written to stderr for some reason
+          ltc = stderr.read.gsub(/[%, ]/, "/")
+          ltc = ltc.split(/.*loss\/=\/[0-9]+\/[0-9]+\/([0-9]+)\/\/\/min\/avg\/max\/=\/([0-9.]+)\/([0-9.]+)\/([0-9.]+)/)[-5..4]
+	  return ltc
+        end
       end
 
     end


### PR DESCRIPTION
Added new latency defs to Fping module, including return values instead of using standard output

I wanted to use this module to return values to send fping metrics to remote destination (graphite in my case). I added two defs:

def \* latency: returns LOSS, MIN, AVG, MAX in an array 
0
13.7
15.5
17.3
(example code @ https://github.com/pythianreese/graphite-smokeping/blob/master/graphite-smokeping.rb)

def \* latency_simple: returns output (not modified)
4.2.2.2 : xmt/rcv/%loss = 6/6/0%, min/avg/max = 13.7/15.5/17.3
