### PR TITLE
Update for fping v4.0

### DIFF
--- a/lib/net/fping.rb
+++ b/lib/net/fping.rb
@@ -7,16 +7,15 @@ module Net
       def default_options
         {
           retries: 3,
-          count: 1,
           bytes: 56,
-          interval: 25,
+          interval: 10,
           timeout: 500
         }
       end
 
       def build_args(opts)
         opts = default_options.merge(opts)
-        "-c #{opts[:count]} -r #{opts[:retries]} -t #{opts[:timeout]} -i #{opts[:interval]} -b #{opts[:bytes]}"
+        "-r #{opts[:retries]} -t #{opts[:timeout]} -i #{opts[:interval]} -b #{opts[:bytes]}"
       end
 
       def alive(hosts=[], **opts)

--- a/net-fping.gemspec
+++ b/net-fping.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "net-fping"
-  spec.version       = "0.3.1"
+  spec.version       = "0.3.2"
   spec.authors       = ["Robert McLeod"]
   spec.email         = ["robert@penguinpower.co.nz"]
   spec.description   = %q{Net-fping is an fping wrapper that allows fast ping checks on multiple remote hosts}


### PR DESCRIPTION
Per Issue #4, this PR updates the `default_options` method to exclude a `count` value, which was broken by [the release of fping v4.0](https://github.com/schweikert/fping/releases/tag/v4.0).

Also updates the default interval to 10ms:

> The default minimum interval between ping probes has been changed from
> 25ms to 10ms. The reason is that 25ms is very high, considering today's
> fast networks: it generates at most 31 kbps of traffic (for IPv4 and
> default payload size).